### PR TITLE
Update license

### DIFF
--- a/LICENSING
+++ b/LICENSING
@@ -5,9 +5,11 @@ You are permitted to distribute binary and source code forms of this software wi
 
 1. You must preserve this entire list of LICENSING information without modification.
 
-2. You must take a photograph of you lifting 10 KG weights and include it within your distribution.
+2. You must take a photograph of you lifting weights with a minimum mass/weight of 10 KG or 25lbs.
 
 3. You must preserve and include such past photographs within your distribution.
+
+4. Extra points for wearing a lifting leotard.
 
 This software is provided "AS IS" and without any express or implied warranties. The contributors and copyright holders SHALL NOT be liable for any kind of damage.
 


### PR DESCRIPTION
Include imperial units and make initial weight the minimum as to allow more advanced lifters to show off. Add Leotard clause.
